### PR TITLE
 Escape special characters in user input and file ID @ablejec ablejec committed 1 minute ago

### DIFF
--- a/Templates/x.lib/pISA.cmd
+++ b/Templates/x.lib/pISA.cmd
@@ -1004,6 +1004,9 @@ set "x=%~3"
 set /p x=Enter %~1 [ %x% ]: 
 rem if %x% EQU "" set x="%~3"
 rem empty answer OK
+Set x=%x:&=[amp]%
+Set x=%x:"=[quot]%
+Set x=%x:'=[apos]%
 if "%x%" EQU "" goto done 
 if "%x%" EQU "*" goto done
 REM Is input required and not entered?
@@ -1389,7 +1392,7 @@ setlocal enableextensions disabledelayedexpansion
     setlocal enabledelayedexpansion
     rem Ensure we do not have restricted characters in file name trying to use them as 
     rem delimiters and requesting the second token in the line
-    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^/^\^|^?^*^ eol^= %%y in ("A!my_file!A") do (
+    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^'^/^\^|^?^!^*^ eol^= %%y in ("A!my_file!A") do (
         rem If we are here there is a second token, so, there is a special character
         echo( Error : Non allowed character in ID
         endlocal & goto :askFile


### PR DESCRIPTION
## Summary by Sourcery

Escape special characters in command-line prompts and strengthen file ID validation

New Features:
- Replace ampersand, double quote, and apostrophe in user input with [amp], [quot], and [apos] respectively

Enhancements:
- Extend file ID character checks to reject apostrophe and exclamation mark as invalid delimiters