### PR TITLE
character replacements and update delimiters in pISA.cmd

### DIFF
--- a/Changes.log
+++ b/Changes.log
@@ -1,0 +1,9 @@
+Changes
+
+* Close #120
+Escape special characters in user input and file ID
+Added logic to replace &, ", and ' with [] entities in user input.
+(7d2cf0d)
+
+* Add restricted characters for file names
+ Updated file ID validation to include ' and ! as restricted characters to prevent invalid input.

--- a/Templates/x.lib/pISA.cmd
+++ b/Templates/x.lib/pISA.cmd
@@ -1004,9 +1004,6 @@ set "x=%~3"
 set /p x=Enter %~1 [ %x% ]: 
 rem if %x% EQU "" set x="%~3"
 rem empty answer OK
-Set x=%x:&=[amp]%
-Set x=%x:"=[quot]%
-Set x=%x:'=[apos]%
 if "%x%" EQU "" goto done 
 if "%x%" EQU "*" goto done
 REM Is input required and not entered?
@@ -1392,7 +1389,7 @@ setlocal enableextensions disabledelayedexpansion
     setlocal enabledelayedexpansion
     rem Ensure we do not have restricted characters in file name trying to use them as 
     rem delimiters and requesting the second token in the line
-    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^'^/^\^|^?^!^*^ eol^= %%y in ("A!my_file!A") do (
+    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^/^\^|^?^*^ eol^= %%y in ("A!my_file!A") do (
         rem If we are here there is a second token, so, there is a special character
         echo( Error : Non allowed character in ID
         endlocal & goto :askFile

--- a/Templates/x.lib/pISA.cmd
+++ b/Templates/x.lib/pISA.cmd
@@ -1004,6 +1004,9 @@ set "x=%~3"
 set /p x=Enter %~1 [ %x% ]: 
 rem if %x% EQU "" set x="%~3"
 rem empty answer OK
+Set x=%x:&=[amp]%
+Set x=%x:"=[quot]%
+Set x=%x:'=[apos]%
 if "%x%" EQU "" goto done 
 if "%x%" EQU "*" goto done
 REM Is input required and not entered?
@@ -1389,7 +1392,7 @@ setlocal enableextensions disabledelayedexpansion
     setlocal enabledelayedexpansion
     rem Ensure we do not have restricted characters in file name trying to use them as 
     rem delimiters and requesting the second token in the line
-    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^/^\^|^?^*^ eol^= %%y in ("A!my_file!A") do (
+    for /f tokens^=2^ delims^=^<^>^:^.^,()$[]^"^'^/^\^|^?^!^*^ eol^= %%y in ("A!my_file!A") do (
         rem If we are here there is a second token, so, there is a special character
         echo( Error : Non allowed character in ID
         endlocal & goto :askFile


### PR DESCRIPTION
replace &, ", and ' characters in user input. Updated the list of restricted delimiters in the for loop to remove ' and !, aligning input validation with new requirements.

## Summary by Sourcery

Sanitize user input by escaping reserved characters and strengthen validation by updating the restricted delimiter list

Enhancements:
- Escape &, ", and ' in user input by replacing them with [amp], [quot], and [apos] tokens
- Extend the for /f loop’s restricted delimiters to include apostrophe and exclamation mark for tighter input validation