### PR TITLE
Fix file path handling and loop parsing in pISA.cmd Closes #134

### DIFF
--- a/Templates/x.lib/pISA.cmd
+++ b/Templates/x.lib/pISA.cmd
@@ -857,18 +857,19 @@ echo # Metadata files>!lfn!
 set "mycd=%cd:\=;%"
 if "%rtyp%" EQU "md" set "mycd=%mycd:_=\_%
 echo %mycd:;=  !LF!/%>>!lfn!
-For /F "tokens=1*" %%i in (src.tmp) do (
+For /F "tokens=1* delims=" %%i in (src.tmp) do (
 	rem (echo(|set /p =## %%i!LF!)>name.tmp
 	rem copy !lfn!+line.tmp !lfn!
 	echo !LF!---!LF!>>!lfn!
 	rem copy !lfn!+name.tmp !lfn!
 	rem Shorten the path( remove project root) and change \ to /
-	set "fname=%%i"
+	set fname="%%i"
 	set "fname=!fname:%cd%= * **!"
-	@echo( !fname!
+	rem @echo( !fname!
 	set "fname=!fname:\=/!"
 	if "%rtyp%" EQU "md" set "fname=!fname:_=\_!"
-	(echo(|set /p =" !fname!**!LF!")>>!lfn!
+	set filename="!fname:"=!**"
+	(echo(|set /p =!filename!!LF!)>>!lfn!
 	echo !LF!---!LF!>>!lfn!
 	REM set /p="TextHere" <nul >>!lfn!
 	REM Add two blanks to each line
@@ -880,7 +881,8 @@ For /F "tokens=1*" %%i in (src.tmp) do (
 		) ELSE (
 		echo Key	Value >> tmpfile.tmp
 		)
-		for /f "delims=" %%l in (%%i) Do (
+		echo %%i
+		for /f "usebackq delims=" %%l in ("%%i") Do (
 			if "%rtyp%" EQU "md" (
 				set "iv=%%l"
 				set "iv=!iv::	=:|!"


### PR DESCRIPTION
Improves file path manipulation by quoting variables and cleaning up path formatting. Updates the For loop to use 'delims=' for correct line parsing and adjusts the inner loop to use 'usebackq' for file reading. These changes enhance robustness and compatibility when processing file names and paths.

## Summary by Sourcery

Enhance file path parsing in pISA.cmd by quoting variables, cleaning up path formatting, and adjusting loop options for robust handling of spaces and special characters.

Bug Fixes:
- Fix For / F loops to correctly capture full lines by adding delims=.
- Use usebackq in inner loop to properly read filenames with spaces.

Enhancements:
- Quote path variables and sanitize their formatting to improve compatibility.
- Streamline filename handling by removing echo clutter and normalizing path separators.